### PR TITLE
Update Google and Zoom credential token automatically as needed.

### DIFF
--- a/main.go
+++ b/main.go
@@ -87,7 +87,7 @@ func NewMux(logger *log.Logger, googleClient *google.Client, zoomClient *zoom.Cl
 			return
 		}
 
-		recordings, err := zoomClient.ListRecordings(time.Now().Add(-168 * time.Hour), "")
+		recordings, err := zoomClient.ListRecordings(time.Now().Add(-168*time.Hour), "")
 		if err != nil {
 			logger.Print(err)
 			http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -305,7 +305,7 @@ func (z *Config) Run(params runParams) error {
 	z.logger.Print("archiving recordings")
 	nextPageToken := ""
 	for {
-		recordings, err := z.zoomClient.ListRecordings(time.Now().Add(-1 * params.since), nextPageToken)
+		recordings, err := z.zoomClient.ListRecordings(time.Now().Add(-1*params.since), nextPageToken)
 		if err != nil {
 			return fmt.Errorf("failed to list recordings: %w", err)
 		}
@@ -355,7 +355,7 @@ func main() {
 	}
 
 	var wg sync.WaitGroup
-	if ! *noServer {
+	if !*noServer {
 		wg.Add(1)
 		server := http.Server{
 			Addr:    *addr,
@@ -375,10 +375,10 @@ func main() {
 		logger.Println("failed to load config", err)
 	}
 
-	if ! googleClient.HasCreds() {
+	if !googleClient.HasCreds() {
 		logger.Println("no google creds")
 	}
-	if ! zoomClient.HasCreds() {
+	if !zoomClient.HasCreds() {
 		logger.Println("no zoom creds")
 	}
 

--- a/zoom/zoom.go
+++ b/zoom/zoom.go
@@ -157,7 +157,23 @@ func (c *Client) updateCreds(token *oauth2.Token) {
 }
 
 func (c *Client) HasCreds() bool {
-	return c.credentials.Valid()
+	valid := c.credentials.Valid()
+	
+	if !valid {
+		c.logger.Println("Zoom credentias not valid, updating token")
+		src := c.config.TokenSource(context.TODO(), c.credentials)
+		newToken, err := src.Token() // this actually goes and renews the tokens
+		if err != nil {
+			c.logger.Printf("error updating google token %w", err)
+			return false
+		}
+		if newToken.AccessToken != c.credentials.AccessToken {
+     		c.updateCreds(newToken)
+     		c.credentials = newToken
+     		c.logger.Println("Zoom credentias updated and saved to disk")
+   		}
+	}
+	return true
 }
 
 func (c *Client) OauthRedirect(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
This is the biggest usability change I needed for this. 
I used the `HasCreds` check to trigger the token update when it fails, happy to change it to somewhere else or add a boolean if we want to prevent updating in some case. It seems to be working for the use case we have, though.

```
2019/12/27 14:16:14 main.go:430: starting archive tool
2019/12/27 14:16:14 google.go:97: Google credentias not valid, updating token
2019/12/27 14:16:14 main.go:510: starting on http://localhost:8080
2019/12/27 14:16:14 google.go:107: Google credentias updated and saved to disk
2019/12/27 14:16:14 zoom.go:163: Zoom credentias not valid, updating token
2019/12/27 14:16:14 zoom.go:173: Zoom credentias updated and saved to disk
2019/12/27 14:16:14 main.go:388: archiving recordings
2019/12/27 14:16:15 main.go:398: skipped 3 minute meeting at 2019-12-23 15:00:09 +0000 UTC
2019/12/27 14:16:16 main.go:297: using existing folder 2019-12-19: https://drive.google.com/drive/folders/xxxxxxxx
2019/12/27 14:16:17 main.go:326: archiving meeting 327806582 to 2019-12-19 (https://drive.google.com/drive/folders/xxxxxx)
2019/12/27 14:16:17 main.go:354: skipping upload 2019-12-19-163121 Documentation Planning.m4a to - Documentation Weekly/2019-12-19, already exists
2019/12/27 14:16:17 main.go:354: skipping upload 2019-12-19-163121 Documentation Planning.timeline.json to - Documentation Weekly/2019-12-19, already exists
2019/12/27 14:16:17 main.go:345: skipped 0 minute recording at 2019-12-19 16:28:53 +0000 UTC - 2019-12-19 16:29:02 +0000 UTC
2019/12/27 14:16:17 main.go:345: skipped 0 minute recording at 2019-12-19 16:28:53 +0000 UTC - 2019-12-19 16:29:02 +0000 UTC
2019/12/27 14:16:17 main.go:345: skipped 0 minute recording at 2019-12-19 16:28:53 +0000 UTC - 2019-12-19 16:29:02 +0000 UTC
2019/12/27 14:16:17 main.go:345: skipped 0 minute recording at 2019-12-19 16:30:33 +0000 UTC - 2019-12-19 16:30:59 +0000 UTC
2019/12/27 14:16:17 main.go:354: skipping upload 2019-12-19-163121 Documentation Planning.mp4 to - Documentation Weekly/2019-12-19, already exists
2019/12/27 14:16:17 main.go:354: skipping upload 2019-12-19-163121 Documentation Planning.vtt to - Documentation Weekly/2019-12-19, already exists
2019/12/27 14:16:17 main.go:345: skipped 0 minute recording at 2019-12-19 16:30:33 +0000 UTC - 2019-12-19 16:30:59 +0000 UTC
```