### PR TITLE
Detect unauthorized downloads

### DIFF
--- a/main.go
+++ b/main.go
@@ -364,6 +364,10 @@ func (z *Config) Archive(meeting zoom.Meeting, params runParams) error {
 			curArchMeeting.status = "error"
 			return fmt.Errorf("download failed, got %d error: %#v", r.StatusCode, r)
 		}
+		if contentType := r.Header.Get("content-type"); strings.HasPrefix(contentType, "text/html") {
+			curArchMeeting.status = "error"
+			return fmt.Errorf("download failed, got %s content", contentType)
+		}
 		_, err = gdrive.Files.Create(&drive.File{
 			Name:    name,
 			Parents: []string{meetingFolder.Id},

--- a/main.go
+++ b/main.go
@@ -362,11 +362,13 @@ func (z *Config) Archive(meeting zoom.Meeting, params runParams) error {
 		}
 		if r.StatusCode != http.StatusOK {
 			curArchMeeting.status = "error"
-			return fmt.Errorf("download failed, got %d error: %#v", r.StatusCode, r)
+			return fmt.Errorf("while downloading recording %s: download failed, got %d error: %#v",
+				f.DownloadURL, r.StatusCode, r)
 		}
 		if contentType := r.Header.Get("content-type"); strings.HasPrefix(contentType, "text/html") {
 			curArchMeeting.status = "error"
-			return fmt.Errorf("download failed, got %s content", contentType)
+			return fmt.Errorf("while downloading recording %s: download failed, got %s content",
+				f.DownloadURL, contentType)
 		}
 		_, err = gdrive.Files.Create(&drive.File{
 			Name:    name,


### PR DESCRIPTION
Work around status code 200 - Password Required

While fetching download_url from zoom without an access token, password
protected recordings return:

	HTTP/2 200
	content-type: text/html;charset=utf-8

	<!doctype html>
	<title>Password Required - Zoom</title>

zat only considers non-html so a content-type check for html detects this.