### PR TITLE
fix-up-tests

### DIFF
--- a/google/google.go
+++ b/google/google.go
@@ -91,6 +91,10 @@ func (c *Client) updateCreds(token *oauth2.Token) {
 }
 
 func (c *Client) HasCreds() bool {
+	if c.credentials == nil {
+		return false
+	}
+
 	valid := c.credentials.Valid()
 
 	if !valid {

--- a/main_test.go
+++ b/main_test.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"golang.org/x/oauth2"
 
@@ -50,7 +51,19 @@ func TestGoogleOauth(t *testing.T) {
 		t.Error(err)
 	}
 
-	mux := NewMux(muxLog, googleClient, nopZoomClient)
+	zat := &Config{
+		logger:       muxLog,
+		copies:       make(map[int64]string, 0),
+		googleClient: googleClient,
+		zoomClient:   nopZoomClient,
+	}
+
+	rp := runParams{
+		minDuration: 5,
+		since:       24 * time.Hour,
+	}
+
+	mux := NewMux(zat, rp)
 	server := httptest.NewServer(mux)
 	defer server.Close()
 
@@ -123,7 +136,19 @@ func TestZoomOauth(t *testing.T) {
 		t.Error(err)
 	}
 
-	mux := NewMux(muxLog, nopGoogleClient, zoomClient)
+	zat := &Config{
+		logger:       muxLog,
+		copies:       make(map[int64]string, 0),
+		googleClient: nopGoogleClient,
+		zoomClient:   zoomClient,
+	}
+
+	rp := runParams{
+		minDuration: 5,
+		since:       24 * time.Hour,
+	}
+
+	mux := NewMux(zat, rp)
 	server := httptest.NewServer(mux)
 	defer server.Close()
 

--- a/main_test.go
+++ b/main_test.go
@@ -23,6 +23,10 @@ import (
 var (
 	nopGoogleClient = &google.Client{}
 	nopZoomClient   = &zoom.Client{}
+	rp              = runParams{
+		minDuration: 5,
+		since:       24 * time.Hour,
+	}
 )
 
 func TestGoogleOauth(t *testing.T) {
@@ -56,11 +60,6 @@ func TestGoogleOauth(t *testing.T) {
 		copies:       make(map[int64]string, 0),
 		googleClient: googleClient,
 		zoomClient:   nopZoomClient,
-	}
-
-	rp := runParams{
-		minDuration: 5,
-		since:       24 * time.Hour,
 	}
 
 	mux := NewMux(zat, rp)
@@ -141,11 +140,6 @@ func TestZoomOauth(t *testing.T) {
 		copies:       make(map[int64]string, 0),
 		googleClient: nopGoogleClient,
 		zoomClient:   zoomClient,
-	}
-
-	rp := runParams{
-		minDuration: 5,
-		since:       24 * time.Hour,
 	}
 
 	mux := NewMux(zat, rp)

--- a/zoom/zoom.go
+++ b/zoom/zoom.go
@@ -157,6 +157,10 @@ func (c *Client) updateCreds(token *oauth2.Token) {
 }
 
 func (c *Client) HasCreds() bool {
+	if c.credentials == nil {
+		return false
+	}
+
 	valid := c.credentials.Valid()
 
 	if !valid {


### PR DESCRIPTION
Looks like the NewMux definition changed and we can't call `HasCreds`
on the no-op client definitions. So I updated the calls and added a
guard.