### PR TITLE
only send notifications for video uploads

### DIFF
--- a/main.go
+++ b/main.go
@@ -375,7 +375,7 @@ func (z *Config) Archive(ctx context.Context, meeting zoom.Meeting, params runPa
 	// download & upload serially for now
 	z.logger.Printf("archiving meeting %d to %s (https://drive.google.com/drive/folders/%s)",
 		meeting.ID, meetingFolder.Name, meetingFolder.Id)
-	uploaded := false
+	notifyUpload := false
 	for _, f := range meeting.RecordingFiles {
 		//check if recording file duration is shorter than minimum
 		start, err := time.Parse(time.RFC3339, f.RecordingStart)
@@ -440,9 +440,11 @@ func (z *Config) Archive(ctx context.Context, meeting zoom.Meeting, params runPa
 		}
 		curArchMeeting.fileNumber++
 		z.logger.Printf("uploaded %q to %s/%s", name, parent.Name, meetingFolder.Name)
-		uploaded = true
+		if strings.ToLower(f.FileType) == "mp4" {
+			notifyUpload = true
+		}
 	}
-	if uploaded && action.Slack != "" && z.slackClient != nil {
+	if notifyUpload && action.Slack != "" && z.slackClient != nil {
 		slackSpan, ctx := apm.StartSpan(ctx, "slack", "app")
 		body := fmt.Sprintf("%s recording now available: https://drive.google.com/drive/folders/%s", meeting.Topic, meetingFolder.Id)
 		channel, _, text, err := z.slackClient.SendMessageContext(ctx, action.Slack, slackapi.MsgOptionText(body, true))


### PR DESCRIPTION
Sometimes transcripts lag behind the other meeting recording files, resulting in two successful upload events for the same recording.  Only send notifications when a video file is uploaded.